### PR TITLE
Update checkbdev to make artixpower define what init it has

### DIFF
--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -68,6 +68,16 @@ if ! mount "$1" "$tmp" -t "$3" -o ro; then
     exit 101
 fi
 
+set_artix_labels() {
+    _suf="$1"
+    ppcDistro="\e[1;36mArtixPOWER${_suf}"
+    ppcDistroHighlighted="\e[36mArtixPOWER${_suf}"
+    otherDistro="\e[1;31mUnknown \e[36mArtix Linux${_suf}"
+    otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux${_suf}"
+    ppcDistroColorLen="7 5"
+    otherDistroColorLen="12 10"
+}
+
 # is it even a Linux (or Android) distro?
 if ! [ -d "$tmp/usr" ] || ! { [ -d "$tmp/lib" ] || [ -L "$tmp/lib" ]; }; then
     # not Normal Linux.... is it Android?
@@ -187,13 +197,7 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             otherDistroColorLen="12 10"
             ;;
         artix)
-	    	isArtix=true # Flag to later check what init ArtixPower is
-            ppcDistro="\e[1;36mArtixPOWER"
-            ppcDistroHighlighted="\e[36mArtixPOWER"
-            otherDistro="\e[1;31mUnknown \e[36mArtix Linux"
-            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux"
-            ppcDistroColorLen="7 5"
-            otherDistroColorLen="12 10"
+	    	isArtix=true
             ;;
         void)
             ppcDistro="\e[1;32mVoid PPC"
@@ -279,30 +283,15 @@ if ! [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
     exitCode=105
 fi
 
-# what init is this copy of ArtixPOWER
-if [ "$isArtix" = "true" ] && [ -n "$init" ] && [ -e "$init" ]; then
+# what init is this copy of ArtixPOWER and set name on Menu accordingly
+if [ "$isArtix" = "true" ] && [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
+    initLabel=""
     case "$(basename "$init")" in
-        openrc-init)
-            ppcDistro="\e[1;36mArtixPOWER (OpenRC)"
-            ppcDistroHighlighted="\e[36mArtixPOWER (OpenRC)"
-            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (OpenRC)"
-            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (OpenRC)"
-            ;;
-        runit-init)
-            ppcDistro="\e[1;36mArtixPOWER (Runit)"
-            ppcDistroHighlighted="\e[36mArtixPOWER (Runit)"
-            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (Runit)"
-            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (Runit)"
-            ;;
-        dinit|dinit-init)
-            ppcDistro="\e[1;36mArtixPOWER (Dinit)"
-            ppcDistroHighlighted="\e[36mArtixPOWER (Dinit)"
-            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (Dinit)"
-            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (Dinit)"
-            ;;
+        openrc-init)        initLabel=" (OpenRC)";;
+        runit-init)         initLabel=" (Runit)";;
+        dinit|dinit-init)   initLabel=" (Dinit)";;
     esac
-    ppcDistroColorLen="7 5"
-    otherDistroColorLen="12 10"
+    set_artix_labels "$initLabel"
 fi
 
 # are we sure we have a PPC distro?

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -60,6 +60,8 @@ exitCode=0
 distro=/._distro$2
 problems=/._problems$2
 colors=/._colors$2
+isArtix=false
+initlabel=""
 
 rm -f $distro $problems $colors
 tmp=$(mktemp -p / -d tmp_checkBdev_XXXXXXXXXX)
@@ -67,16 +69,6 @@ if ! mount "$1" "$tmp" -t "$3" -o ro; then
     prob "failed to mount"
     exit 101
 fi
-
-set_artix_labels() {
-    _suf="$1"
-    ppcDistro="\e[1;36mArtixPOWER${_suf}"
-    ppcDistroHighlighted="\e[36mArtixPOWER${_suf}"
-    otherDistro="\e[1;31mUnknown \e[36mArtix Linux${_suf}"
-    otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux${_suf}"
-    ppcDistroColorLen="7 5"
-    otherDistroColorLen="12 10"
-}
 
 # is it even a Linux (or Android) distro?
 if ! [ -d "$tmp/usr" ] || ! { [ -d "$tmp/lib" ] || [ -L "$tmp/lib" ]; }; then
@@ -198,6 +190,12 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             ;;
         artix)
 	    	isArtix=true
+            ppcDistro="\e[1;36mArtixPOWER"
+            ppcDistroHighlighted="\e[36mArtixPOWER"
+            otherDistro="\e[1;31mUnknown \e[36mArtix Linux"
+            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux"
+            ppcDistroColorLen="7 5"
+            otherDistroColorLen="12 10"
             ;;
         void)
             ppcDistro="\e[1;32mVoid PPC"
@@ -285,13 +283,15 @@ fi
 
 # what init is this copy of ArtixPOWER and set name on Menu accordingly
 if [ "$isArtix" = "true" ] && [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
-    initLabel=""
     case "$(basename "$init")" in
         openrc-init)        initLabel=" (OpenRC)";;
         runit-init)         initLabel=" (Runit)";;
         dinit|dinit-init)   initLabel=" (Dinit)";;
     esac
-    set_artix_labels "$initLabel"
+    ppcDistro="${ppcDistro}${initLabel}"
+    ppcDistroHighlighted="${ppcDistroHighlighted}${initLabel}"
+    otherDistro="${otherDistro}${initLabel}"
+    otherDistroHighlighted="${otherDistroHighlighted}${initLabel}"
 fi
 
 # are we sure we have a PPC distro?

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -187,7 +187,7 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             otherDistroColorLen="12 10"
             ;;
         artix)
-	    	isArtix=true #for the init check system
+	    	isArtix=true # Flag to later check what init ArtixPower is
             ppcDistro="\e[1;36mArtixPOWER"
             ppcDistroHighlighted="\e[36mArtixPOWER"
             otherDistro="\e[1;31mUnknown \e[36mArtix Linux"
@@ -279,7 +279,7 @@ if ! [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
     exitCode=105
 fi
 
-# what the init are u supposed to be?
+# what init is this copy of ArtixPOWER
 if [ "$isArtix" = "true" ] && [ -n "$init" ] && [ -e "$init" ]; then
     case "$(basename "$init")" in
         openrc-init)

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -187,6 +187,7 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             otherDistroColorLen="12 10"
             ;;
         artix)
+	    isArtix=true #for the init check system
             ppcDistro="\e[1;36mArtixPOWER"
             ppcDistroHighlighted="\e[36mArtixPOWER"
             otherDistro="\e[1;31mUnknown \e[36mArtix Linux"
@@ -278,6 +279,31 @@ if ! [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
     exitCode=105
 fi
 
+# what the init are u supposed to be?
+if [ "$isArtix" = "true" ] && [ -n "$init" ] && [ -e "$init" ]; then
+    case "$(basename "$init")" in
+        openrc-init)
+            ppcDistro="\e[1;36mArtixPOWER (OpenRC)"
+            ppcDistroHighlighted="\e[36mArtixPOWER (OpenRC)"
+            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (OpenRC)"
+            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (OpenRC)"
+            ;;
+        runit-init)
+            ppcDistro="\e[1;36mArtixPOWER (Runit)"
+            ppcDistroHighlighted="\e[36mArtixPOWER (Runit)"
+            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (Runit)"
+            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (Runit)"
+            ;;
+        dinit|dinit-init)
+            ppcDistro="\e[1;36mArtixPOWER (Dinit)"
+            ppcDistroHighlighted="\e[36mArtixPOWER (Dinit)"
+            otherDistro="\e[1;31mUnknown \e[36mArtix Linux (Dinit)"
+            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux (Dinit)"
+            ;;
+    esac
+    ppcDistroColorLen="7 5"
+    otherDistroColorLen="12 10"
+fi
 
 # are we sure we have a PPC distro?
 if [ -f "$init" ] && [ "$batoceraSquashfs" != "true" ]; then

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -286,19 +286,6 @@ if ! [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
     exitCode=105
 fi
 
-# what init is this copy of ArtixPOWER and set name on Menu accordingly
-if [ "$isArtix" = "true" ] && [ -x "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
-    case "$(basename "$init")" in
-        openrc-init)        initLabel=" (OpenRC)";;
-        runit-init)         initLabel=" (Runit)";;
-        dinit|dinit-init)   initLabel=" (Dinit)";;
-    esac
-    ppcDistro="${ppcDistro}${initLabel}"
-    ppcDistroHighlighted="${ppcDistroHighlighted}${initLabel}"
-    otherDistro="${otherDistro}${initLabel}"
-    otherDistroHighlighted="${otherDistroHighlighted}${initLabel}"
-fi
-
 # are we sure we have a PPC distro?
 if [ -f "$init" ] && [ "$batoceraSquashfs" != "true" ]; then
     out=$(file -L "$init")

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -60,8 +60,6 @@ exitCode=0
 distro=/._distro$2
 problems=/._problems$2
 colors=/._colors$2
-isArtix=false
-initlabel=""
 
 rm -f $distro $problems $colors
 tmp=$(mktemp -p / -d tmp_checkBdev_XXXXXXXXXX)
@@ -189,11 +187,18 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             otherDistroColorLen="12 10"
             ;;
         artix)
-	    	isArtix=true
-            ppcDistro="\e[1;36mArtixPOWER"
-            ppcDistroHighlighted="\e[36mArtixPOWER"
-            otherDistro="\e[1;31mUnknown \e[36mArtix Linux"
-            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux"
+            initLabel=""
+            if   [ -x "$tmp/sbin/openrc-init" ] || [ -d "$tmp/etc/openrc" ] || [ -d "$tmp/etc/init.d" ]; then
+                initLabel=" (OpenRC)"
+            elif [ -x "$tmp/sbin/runit-init" ]  || [ -d "$tmp/etc/runit" ] || [ -d "$tmp/etc/sv" ]; then
+                initLabel=" (Runit)"
+            elif [ -x "$tmp/sbin/dinit" ] || [ -x "$tmp/bin/dinit" ] || [ -d "$tmp/etc/dinit.d" ]; then
+                initLabel=" (Dinit)"
+            fi
+            ppcDistro="\e[1;36mArtixPOWER${initLabel}"
+            ppcDistroHighlighted="\e[36mArtixPOWER${initLabel}"
+            otherDistro="\e[1;31mUnknown \e[36mArtix Linux${initLabel}"
+            otherDistroHighlighted="\e[31mUnknown \e[36mArtix Linux${initLabel}"
             ppcDistroColorLen="7 5"
             otherDistroColorLen="12 10"
             ;;

--- a/loader-img-full/checkBdev.sh
+++ b/loader-img-full/checkBdev.sh
@@ -187,7 +187,7 @@ if [ "$android" != "true" ] && [ "$batoceraSquashfs" != "true" ]; then
             otherDistroColorLen="12 10"
             ;;
         artix)
-	    isArtix=true #for the init check system
+	    	isArtix=true #for the init check system
             ppcDistro="\e[1;36mArtixPOWER"
             ppcDistroHighlighted="\e[36mArtixPOWER"
             otherDistro="\e[1;31mUnknown \e[36mArtix Linux"


### PR DESCRIPTION
Just shows what init ArtixPOWER is next to name so if its openrc it does ArtixPOWER (OpenRC), runit would be ArtixPOWER (Runit) and etc.